### PR TITLE
feat: refresh UI with modern dark theme

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,6 +10,12 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+// Mock axios to prevent ESM import issues during tests
+jest.mock('axios', () => ({ get: jest.fn() }));
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders application title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // The title appears in both the sidebar and top bar; check at least one instance
+  const titleElement = screen.getAllByText(/LexCognito/i)[0];
+  expect(titleElement).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline, Box } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Sidebar from './components/Layout/Sidebar';
@@ -14,48 +14,7 @@ import CloudConsultation from './pages/CloudConsultation';
 import AnalyticsPage from './pages/AnalyticsPage';
 import ClaudeCliNativePage from './pages/ClaudeCliNativePage';
 import DiagnosticsPage from './pages/DiagnosticsPage';
-
-// LexCognito theme
-const theme = createTheme({
-  palette: {
-    mode: 'light',
-    primary: {
-      main: '#1f4e79', // Legal blue
-      dark: '#0d2a47',
-      light: '#4a73a8'
-    },
-    secondary: {
-      main: '#c8a882', // Legal gold
-      dark: '#8b7355',
-      light: '#e6c5a3'
-    },
-    background: {
-      default: '#fafafa',
-      paper: '#ffffff'
-    }
-  },
-  typography: {
-    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-    h4: {
-      fontWeight: 600,
-      color: '#1f4e79'
-    },
-    h5: {
-      fontWeight: 500,
-      color: '#1f4e79'
-    }
-  },
-  components: {
-    MuiDrawer: {
-      styleOverrides: {
-        paper: {
-          backgroundColor: '#1f4e79',
-          color: 'white'
-        }
-      }
-    }
-  }
-});
+import theme from './theme';
 
 const drawerWidth = 280;
 

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -55,8 +55,10 @@ const Sidebar: React.FC<SidebarProps> = ({ drawerWidth, open }) => {
         '& .MuiDrawer-paper': {
           width: drawerWidth,
           boxSizing: 'border-box',
-          bgcolor: 'primary.main',
-          color: 'white'
+          // Modern dark gradient with subtle divider
+          background: 'linear-gradient(180deg, #1e1e1e 0%, #121212 100%)',
+          color: 'white',
+          borderRight: '1px solid rgba(255,255,255,0.12)'
         },
       }}
       variant="persistent"
@@ -94,28 +96,23 @@ const Sidebar: React.FC<SidebarProps> = ({ drawerWidth, open }) => {
               sx={{
                 borderRadius: 2,
                 mx: 1,
-                color: 'white',
+                color: 'rgba(255,255,255,0.8)',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.1)'
+                  bgcolor: 'rgba(255,255,255,0.08)'
                 },
                 ...(location.pathname === item.path && {
-                  bgcolor: 'secondary.main',
-                  color: 'primary.main',
+                  bgcolor: 'primary.main',
+                  color: '#fff',
                   '&:hover': {
-                    bgcolor: 'secondary.light'
+                    bgcolor: 'primary.dark'
                   }
                 })
               }}
             >
-              <ListItemIcon 
-                sx={{ 
-                  color: location.pathname === item.path ? 'primary.main' : 'white',
-                  minWidth: 40
-                }}
-              >
+              <ListItemIcon sx={{ color: 'inherit', minWidth: 40 }}>
                 {item.icon}
               </ListItemIcon>
-              <ListItemText 
+              <ListItemText
                 primary={item.text}
                 primaryTypographyProps={{
                   fontSize: '0.9rem',

--- a/frontend/src/components/Layout/TopBar.tsx
+++ b/frontend/src/components/Layout/TopBar.tsx
@@ -68,6 +68,10 @@ const TopBar: React.FC<TopBarProps> = ({ drawerWidth, sidebarOpen, toggleSidebar
   return (
     <AppBar
       position="fixed"
+      /*
+       * Use a translucent background with blur for a modern "glass" effect.
+       * The bar adapts its width and margin when the sidebar is toggled.
+       */
       sx={{
         width: sidebarOpen ? `calc(100% - ${drawerWidth}px)` : '100%',
         ml: sidebarOpen ? `${drawerWidth}px` : 0,
@@ -75,9 +79,11 @@ const TopBar: React.FC<TopBarProps> = ({ drawerWidth, sidebarOpen, toggleSidebar
           easing: theme.transitions.easing.sharp,
           duration: theme.transitions.duration.leavingScreen,
         }),
-        bgcolor: 'white',
-        color: 'primary.main',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+        bgcolor: 'rgba(18,18,18,0.8)',
+        backdropFilter: 'blur(8px)',
+        borderBottom: '1px solid rgba(255,255,255,0.12)',
+        color: 'text.primary',
+        boxShadow: 'none'
       }}
     >
       <Toolbar>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,12 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #121212;
+  color: rgba(255, 255, 255, 0.87);
 }
 
 code {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,40 @@
+import { createTheme } from '@mui/material/styles';
+
+/**
+ * Modern dark theme for the LexCognito interface.
+ * Provides a sleek palette, subtle rounding and removes default paper images.
+ */
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#7e57c2', // Soft purple accent
+    },
+    secondary: {
+      main: '#26c6da', // Teal accent
+    },
+    background: {
+      default: '#121212',
+      paper: '#1e1e1e',
+    },
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 500 },
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- introduce reusable dark theme with rounded components
- restyle top bar and sidebar for a sleek glassy look
- load Inter font and update global styles

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d5fcc64832d9d57834cf298c017